### PR TITLE
Add OAuth Device Authorization Flow support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ server_log.log
 # AI/IDE Tools
 .claude
 .vscode/
+docs/superpowers/
 
 # Python
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,12 @@ dependencies = [
     "starlette>=0.49.1",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]
+
 [project.urls]
 Homepage = "https://github.com/kionsoftware/kion-mcp"
 Repository = "https://github.com/kionsoftware/kion-mcp"

--- a/src/kion_mcp/config/auth.py
+++ b/src/kion_mcp/config/auth.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import logging
 from pathlib import Path
-# No typing imports needed currently
 from .settings import KionConfig
 from ..exceptions import AuthenticationError
 from ..interaction.elicitation import elicit_bearer_token
@@ -12,18 +11,30 @@ from ..interaction.elicitation import elicit_bearer_token
 
 class AuthManager:
     """Manages authentication for Kion API."""
-    
+
     def __init__(self, config: KionConfig):
         self.config = config
-    
+        self._oauth_manager = None
+
+        # Lazily create OAuthManager if oauth_client_id is configured
+        if config.is_oauth_mode():
+            from .oauth import OAuthManager
+            self._oauth_manager = OAuthManager(config)
+
     def get_bearer_token(self, reload_config: bool = False) -> str:
-        """Get bearer token from config or auth script.
-        
+        """Get bearer token from config, OAuth cache, or auth script.
+
+        Priority: bearer_token > cached OAuth token > auth script.
+
+        Note: For OAuth device flow (which is async), callers should use
+        the 401 retry mechanism which calls refresh_bearer_token_with_elicitation().
+        This sync method only checks synchronous sources.
+
         Args:
             reload_config: If True, reload config from file before getting token
         """
         logging.info("Getting bearer token")
-        
+
         # Reload config from file if requested
         if reload_config:
             logging.info("Reloading config from file")
@@ -31,56 +42,95 @@ class AuthManager:
                 self.config.reload()
             except Exception as e:
                 logging.warning(f"Failed to reload config: {e}")
-        
-        # Check if auth script path is provided in config
+
+        # Priority 1: Static bearer token
+        if self.config.bearer_token and not self.config._is_placeholder_value('bearer_token', self.config.bearer_token):
+            logging.info("Using bearer token from config")
+            return self.config.bearer_token
+
+        # Priority 2: Cached OAuth token (sync check only)
+        if self._oauth_manager:
+            cache = self._oauth_manager._load_token_cache()
+            if cache and cache.get("access_token"):
+                expires_at = cache.get("access_token_expires_at", 0)
+                if not self._oauth_manager._is_token_expired(expires_at):
+                    logging.info("Using cached OAuth access token")
+                    return cache["access_token"]
+            # OAuth is configured but no valid cached token —
+            # return what we have and let the 401 retry handle async refresh
+            if cache and cache.get("access_token"):
+                logging.info("Using expired OAuth token (will refresh on 401)")
+                return cache["access_token"]
+
+        # Priority 3: Auth script
         if self.config.auth_script_path:
             return self._get_token_from_script()
-        
-        # Fall back to bearer_token from config file
+
+        # Priority 4: Fall back to bearer_token even if it looks like a placeholder
         if self.config.bearer_token:
             logging.info("Using bearer token from config file")
             return self.config.bearer_token
-        
-        raise AuthenticationError("No auth script path or bearer token found in config")
-    
+
+        raise AuthenticationError("No authentication method configured (bearer_token, oauth_client_id, or auth_script_path)")
+
     def _get_token_from_script(self) -> str:
         """Get bearer token from auth script."""
         auth_script_path = self.config.auth_script_path
-        
+
         try:
             # Support both absolute and relative paths
             if not os.path.isabs(auth_script_path):
                 # Make relative to the root of the project
                 auth_script_path = (Path(__file__).parent.parent.parent.parent / auth_script_path).resolve()
-            
+
             logging.info(f"Executing auth script at: {auth_script_path}")
             result = subprocess.run([auth_script_path], capture_output=True, text=True, check=True)
             bearer_token = result.stdout.strip()
             logging.info(f"Successfully retrieved bearer token from auth script")
             return bearer_token
-            
+
         except subprocess.CalledProcessError as e:
             raise AuthenticationError(f"Failed to get bearer token from auth script: {e}")
         except Exception as e:
             raise AuthenticationError(f"Error executing auth script: {e}")
-    
+
     async def refresh_bearer_token_with_elicitation(self, ctx=None):
-        """Try to refresh bearer token via elicitation if not in script mode."""
+        """Try to refresh bearer token via OAuth, elicitation, or script.
+
+        Priority for refresh:
+        1. OAuth refresh token (if in OAuth mode)
+        2. OAuth device flow re-auth (if in OAuth mode)
+        3. Auth script re-execution (if in script mode)
+        4. Elicitation for new bearer token (interactive)
+        """
+        # OAuth mode: try refresh, then device flow
+        if self._oauth_manager:
+            # Try refresh token first
+            success, token_or_msg = await self._oauth_manager.refresh_access_token()
+            if success:
+                return True, token_or_msg
+
+            # Try device flow re-auth
+            success, token_or_msg = await self._oauth_manager.run_device_flow(ctx)
+            if success:
+                return True, token_or_msg
+
+            return False, f"OAuth authentication failed: {token_or_msg}"
+
+        # Script mode: re-execute script
         if self.config.is_script_auth_mode():
-            # In script mode, just use existing get_bearer_token
             token = self.get_bearer_token()
             return bool(token), token
-        
+
+        # Interactive mode: elicit new token
         if ctx is None:
             return False, "No context available for token elicitation"
-        
-        # Try elicitation for new token
+
         logging.info("Attempting to elicit new bearer token")
         success, new_token = await elicit_bearer_token(ctx)
         new_token = new_token.strip()
-        
+
         if success and new_token:
-            # Update config file with new token
             try:
                 self.config.bearer_token = new_token
                 self.config.save()
@@ -89,5 +139,5 @@ class AuthManager:
             except Exception as e:
                 logging.error(f"Failed to update config with new token: {e}")
                 return False, f"Failed to save new token: {e}"
-        
+
         return False, "Token elicitation failed or was cancelled"

--- a/src/kion_mcp/config/oauth.py
+++ b/src/kion_mcp/config/oauth.py
@@ -312,7 +312,11 @@ class OAuthManager:
         if not verification_url:
             verification_url = self._oauth_url(f"/oauth/device?user_code={user_code}")
 
-        browser_opened = self._open_browser(verification_url)
+        # For local dev: the OAuth server returns the API port (8081) but
+        # the device approval page is served by the frontend (8080).
+        browser_url = verification_url.replace(":8081", ":8080")
+
+        browser_opened = self._open_browser(browser_url)
 
         if ctx:
             await elicit_device_code_approval(ctx, user_code, verification_url)

--- a/src/kion_mcp/config/oauth.py
+++ b/src/kion_mcp/config/oauth.py
@@ -91,3 +91,261 @@ class OAuthManager:
             logging.info("Token cache cleared")
         except OSError as exc:
             logging.warning("Failed to clear token cache: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Device Authorization Flow
+    # ------------------------------------------------------------------
+
+    async def _request_device_authorization(self) -> dict:
+        """Request device authorization from the OAuth server.
+        POST /oauth/device_authorization with client_id and scopes.
+        Returns dict with device_code, user_code, verification_uri, expires_in, interval.
+        Raises AuthenticationError on failure.
+        """
+        url = f"{self.config.server_base_url}/oauth/device_authorization"
+        url = url.replace("/api/oauth/", "/oauth/")
+
+        data = {
+            "client_id": self.config.oauth_client_id,
+            "scope": self.config.oauth_scopes,
+        }
+
+        response = httpx.post(url, data=data, timeout=15)
+
+        if response.status_code == 404:
+            raise AuthenticationError(
+                "OAuth is not enabled on this Kion instance. "
+                "Use a bearer token or auth script instead."
+            )
+
+        if response.status_code != 200:
+            try:
+                err = response.json()
+                error_code = err.get("error", "unknown")
+                error_desc = err.get("error_description", response.text)
+                raise AuthenticationError(
+                    f"Device authorization failed: {error_code} — {error_desc}"
+                )
+            except (ValueError, KeyError):
+                raise AuthenticationError(
+                    f"Device authorization failed: HTTP {response.status_code} {response.text}"
+                )
+
+        return response.json()
+
+    async def _poll_for_token(self, device_code: str, interval: int, expires_in: int) -> dict:
+        """Poll the token endpoint until user approves or code expires.
+        Returns dict with access_token, token_type, expires_in, and optionally refresh_token.
+        Raises AuthenticationError on denial, expiry, or unexpected error.
+        """
+        import asyncio
+
+        url = f"{self.config.server_base_url}/oauth/token"
+        url = url.replace("/api/oauth/", "/oauth/")
+
+        data = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": self.config.oauth_client_id,
+        }
+
+        deadline = time.time() + expires_in
+        poll_interval = interval
+
+        while time.time() < deadline:
+            await asyncio.sleep(poll_interval)
+
+            response = httpx.post(url, data=data, timeout=15)
+
+            try:
+                body = response.json()
+            except ValueError:
+                raise AuthenticationError(
+                    f"Unexpected response from token endpoint: {response.text}"
+                )
+
+            error = body.get("error")
+            if error:
+                if error == "authorization_pending":
+                    continue
+                elif error == "slow_down":
+                    poll_interval += 5
+                    continue
+                elif error == "access_denied":
+                    raise AuthenticationError("Authorization denied by user")
+                elif error == "expired_token":
+                    raise AuthenticationError("Device code expired")
+                else:
+                    desc = body.get("error_description", "")
+                    raise AuthenticationError(f"Token error: {error} — {desc}")
+
+            if body.get("access_token"):
+                return body
+
+        raise AuthenticationError("Device code expired (polling deadline reached)")
+
+    # ------------------------------------------------------------------
+    # Token Refresh
+    # ------------------------------------------------------------------
+
+    async def _refresh_token(self, refresh_token: str) -> dict:
+        """Exchange a refresh token for new tokens.
+        POST /oauth/token with grant_type=refresh_token.
+        Raises AuthenticationError on failure.
+        """
+        url = f"{self.config.server_base_url}/oauth/token"
+        url = url.replace("/api/oauth/", "/oauth/")
+
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": self.config.oauth_client_id,
+        }
+
+        response = httpx.post(url, data=data, timeout=15)
+
+        try:
+            body = response.json()
+        except ValueError:
+            raise AuthenticationError(
+                f"Unexpected response from token endpoint: {response.text}"
+            )
+
+        if response.status_code != 200:
+            error = body.get("error", "unknown")
+            desc = body.get("error_description", "")
+            raise AuthenticationError(f"Token refresh failed: {error} — {desc}")
+
+        return body
+
+    async def refresh_access_token(self) -> tuple[bool, str]:
+        """Attempt to refresh the access token using a cached refresh token.
+        Returns (True, new_access_token) on success, (False, error_message) on failure.
+        """
+        cache = self._load_token_cache()
+        if not cache or not cache.get("refresh_token"):
+            return False, "No refresh token available"
+
+        refresh_expires = cache.get("refresh_token_expires_at", 0)
+        if self._is_token_expired(refresh_expires):
+            logging.info("Refresh token expired, clearing cache")
+            self.clear_cached_tokens()
+            return False, "Refresh token expired"
+
+        try:
+            token_data = await self._refresh_token(cache["refresh_token"])
+            access_token = token_data["access_token"]
+            new_refresh = token_data.get("refresh_token", cache["refresh_token"])
+            expires_in = token_data.get("expires_in", 3600)
+
+            self._save_token_cache(access_token, new_refresh, expires_in)
+            logging.info("Access token refreshed successfully")
+            return True, access_token
+
+        except AuthenticationError as exc:
+            logging.warning("Token refresh failed: %s", exc)
+            self.clear_cached_tokens()
+            return False, str(exc)
+
+    # ------------------------------------------------------------------
+    # Browser Launch
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _open_browser(url: str) -> bool:
+        """Attempt to open a URL in the system browser.
+        Returns True if the browser command was launched.
+        """
+        system = platform.system()
+        try:
+            if system == "Darwin":
+                subprocess.Popen(["open", url])
+            elif system == "Linux":
+                subprocess.Popen(["xdg-open", url])
+            elif system == "Windows":
+                subprocess.Popen(["rundll32", "url.dll,FileProtocolHandler", url])
+            else:
+                logging.warning("Unknown OS %s, cannot open browser", system)
+                return False
+            return True
+        except OSError as exc:
+            logging.warning("Failed to open browser: %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # Full Device Flow & Main Entry Point
+    # ------------------------------------------------------------------
+
+    async def run_device_flow(self, ctx=None) -> tuple[bool, str]:
+        """Run the full OAuth device authorization flow.
+        Shows user code via elicitation and opens browser.
+        Polls until user approves or code expires.
+        Returns (True, access_token) on success, (False, error_message) on failure.
+        """
+        from ..interaction.elicitation import elicit_device_code_approval
+
+        try:
+            device_resp = await self._request_device_authorization()
+        except AuthenticationError as exc:
+            return False, str(exc)
+
+        user_code = device_resp["user_code"]
+        device_code = device_resp["device_code"]
+        interval = device_resp.get("interval", 5)
+        expires_in = device_resp.get("expires_in", 900)
+
+        verification_url = device_resp.get("verification_uri_complete") or device_resp.get("verification_uri", "")
+        if not verification_url:
+            base = self.config.server_base_url.replace("/api", "")
+            verification_url = f"{base}/oauth/device?user_code={user_code}"
+
+        browser_opened = self._open_browser(verification_url)
+
+        if ctx:
+            await elicit_device_code_approval(ctx, user_code, verification_url)
+        elif not browser_opened:
+            logging.warning(
+                "OAuth device flow: visit %s and enter code %s",
+                verification_url, user_code,
+            )
+
+        try:
+            token_data = await self._poll_for_token(device_code, interval, expires_in)
+            access_token = token_data["access_token"]
+            refresh_token = token_data.get("refresh_token")
+            token_expires_in = token_data.get("expires_in", 3600)
+
+            self._save_token_cache(access_token, refresh_token, token_expires_in)
+            logging.info("Device flow authentication successful")
+            return True, access_token
+
+        except AuthenticationError as exc:
+            self.clear_cached_tokens()
+            return False, str(exc)
+
+    async def get_access_token(self, ctx=None) -> str:
+        """Get a valid access token, using cache, refresh, or device flow.
+        This is the main entry point for obtaining an OAuth token.
+        Follows the chain: cached token -> refresh token -> device flow.
+        Raises AuthenticationError if all methods fail.
+        """
+        # Step 1: Check for a valid cached access token
+        cache = self._load_token_cache()
+        if cache and cache.get("access_token"):
+            expires_at = cache.get("access_token_expires_at", 0)
+            if not self._is_token_expired(expires_at):
+                logging.info("Using cached access token")
+                return cache["access_token"]
+
+        # Step 2: Try refresh token
+        success, token_or_msg = await self.refresh_access_token()
+        if success:
+            return token_or_msg
+
+        # Step 3: Fall back to device flow
+        logging.info("Falling back to device authorization flow")
+        success, token_or_msg = await self.run_device_flow(ctx)
+        if success:
+            return token_or_msg
+
+        raise AuthenticationError(f"OAuth authentication failed: {token_or_msg}")

--- a/src/kion_mcp/config/oauth.py
+++ b/src/kion_mcp/config/oauth.py
@@ -27,6 +27,18 @@ class OAuthManager:
     def __init__(self, config: KionConfig):
         self.config = config
 
+    def _oauth_url(self, path: str) -> str:
+        """Build an OAuth endpoint URL at the server root (outside /api).
+
+        OAuth endpoints live at the root of the Kion instance, e.g.:
+          /device_authorization, /token, /authorize
+        But server_base_url typically ends with /api, so we strip it.
+        """
+        base = self.config.server_base_url.rstrip("/")
+        if base.endswith("/api"):
+            base = base[:-4]
+        return f"{base}{path}"
+
     @staticmethod
     def _cache_file_path() -> Path:
         """Return the path to the token cache file."""
@@ -104,8 +116,7 @@ class OAuthManager:
         Returns dict with device_code, user_code, verification_uri, expires_in, interval.
         Raises AuthenticationError on failure.
         """
-        url = f"{self.config.server_base_url}/oauth/device_authorization"
-        url = url.replace("/api/oauth/", "/oauth/")
+        url = self._oauth_url("/device_authorization")
 
         data = {
             "client_id": self.config.oauth_client_id,
@@ -143,8 +154,7 @@ class OAuthManager:
         """
         import asyncio
 
-        url = f"{self.config.server_base_url}/oauth/token"
-        url = url.replace("/api/oauth/", "/oauth/")
+        url = self._oauth_url("/token")
 
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
@@ -197,8 +207,7 @@ class OAuthManager:
         POST /oauth/token with grant_type=refresh_token.
         Raises AuthenticationError on failure.
         """
-        url = f"{self.config.server_base_url}/oauth/token"
-        url = url.replace("/api/oauth/", "/oauth/")
+        url = self._oauth_url("/token")
 
         data = {
             "grant_type": "refresh_token",
@@ -301,8 +310,7 @@ class OAuthManager:
 
         verification_url = device_resp.get("verification_uri_complete") or device_resp.get("verification_uri", "")
         if not verification_url:
-            base = self.config.server_base_url.replace("/api", "")
-            verification_url = f"{base}/oauth/device?user_code={user_code}"
+            verification_url = self._oauth_url(f"/oauth/device?user_code={user_code}")
 
         browser_opened = self._open_browser(verification_url)
 

--- a/src/kion_mcp/config/oauth.py
+++ b/src/kion_mcp/config/oauth.py
@@ -1,0 +1,93 @@
+"""OAuth Device Authorization Flow manager for Kion MCP Server."""
+
+import json
+import logging
+import platform
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from .settings import KionConfig
+from ..exceptions import AuthenticationError
+
+# Token expiry buffer — consider tokens expired 30 seconds early
+_EXPIRY_BUFFER_SECONDS = 30
+
+# Default refresh token lifetime estimate (30 days, portal default)
+_DEFAULT_REFRESH_TOKEN_LIFETIME = 30 * 24 * 3600
+
+
+class OAuthManager:
+    """Manages OAuth Device Authorization Flow for Kion API."""
+
+    def __init__(self, config: KionConfig):
+        self.config = config
+
+    @staticmethod
+    def _cache_file_path() -> Path:
+        """Return the path to the token cache file."""
+        return Path.home() / ".kion_mcp_token_cache.json"
+
+    def _load_token_cache(self) -> Optional[dict]:
+        """Load and validate the token cache file.
+
+        Returns None if the file is missing, corrupt, or belongs to a
+        different server URL.
+        """
+        cache_path = self._cache_file_path()
+        if not cache_path.exists():
+            return None
+
+        try:
+            with open(cache_path, "r") as f:
+                cache = json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            logging.warning("Token cache unreadable, ignoring: %s", exc)
+            return None
+
+        # Invalidate if server URL changed
+        if cache.get("server_url") != self.config.server_base_url:
+            logging.info("Token cache server_url mismatch, ignoring")
+            return None
+
+        return cache
+
+    def _save_token_cache(
+        self,
+        access_token: str,
+        refresh_token: Optional[str],
+        access_expires_in: int,
+    ) -> None:
+        """Write tokens to the cache file with absolute expiry timestamps."""
+        now = time.time()
+        cache = {
+            "server_url": self.config.server_base_url,
+            "access_token": access_token,
+            "access_token_expires_at": now + access_expires_in,
+            "refresh_token": refresh_token,
+            "refresh_token_expires_at": now + _DEFAULT_REFRESH_TOKEN_LIFETIME,
+        }
+        try:
+            cache_path = self._cache_file_path()
+            with open(cache_path, "w") as f:
+                json.dump(cache, f, indent=2)
+            logging.info("Token cache saved to %s", cache_path)
+        except OSError as exc:
+            logging.warning("Failed to write token cache: %s", exc)
+
+    @staticmethod
+    def _is_token_expired(expiry_timestamp: float) -> bool:
+        """Check if a token has expired (with buffer)."""
+        return time.time() >= expiry_timestamp - _EXPIRY_BUFFER_SECONDS
+
+    def clear_cached_tokens(self) -> None:
+        """Remove the token cache file."""
+        cache_path = self._cache_file_path()
+        try:
+            cache_path.unlink(missing_ok=True)
+            logging.info("Token cache cleared")
+        except OSError as exc:
+            logging.warning("Failed to clear token cache: %s", exc)

--- a/src/kion_mcp/config/oauth.py
+++ b/src/kion_mcp/config/oauth.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import platform
 import subprocess
 import time
@@ -72,7 +73,8 @@ class OAuthManager:
         }
         try:
             cache_path = self._cache_file_path()
-            with open(cache_path, "w") as f:
+            fd = os.open(str(cache_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
                 json.dump(cache, f, indent=2)
             logging.info("Token cache saved to %s", cache_path)
         except OSError as exc:
@@ -110,7 +112,8 @@ class OAuthManager:
             "scope": self.config.oauth_scopes,
         }
 
-        response = httpx.post(url, data=data, timeout=15)
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, data=data, timeout=15)
 
         if response.status_code == 404:
             raise AuthenticationError(
@@ -152,35 +155,36 @@ class OAuthManager:
         deadline = time.time() + expires_in
         poll_interval = interval
 
-        while time.time() < deadline:
-            await asyncio.sleep(poll_interval)
+        async with httpx.AsyncClient() as client:
+            while time.time() < deadline:
+                await asyncio.sleep(poll_interval)
 
-            response = httpx.post(url, data=data, timeout=15)
+                response = await client.post(url, data=data, timeout=15)
 
-            try:
-                body = response.json()
-            except ValueError:
-                raise AuthenticationError(
-                    f"Unexpected response from token endpoint: {response.text}"
-                )
+                try:
+                    body = response.json()
+                except ValueError:
+                    raise AuthenticationError(
+                        f"Unexpected response from token endpoint: {response.text}"
+                    )
 
-            error = body.get("error")
-            if error:
-                if error == "authorization_pending":
-                    continue
-                elif error == "slow_down":
-                    poll_interval += 5
-                    continue
-                elif error == "access_denied":
-                    raise AuthenticationError("Authorization denied by user")
-                elif error == "expired_token":
-                    raise AuthenticationError("Device code expired")
-                else:
-                    desc = body.get("error_description", "")
-                    raise AuthenticationError(f"Token error: {error} — {desc}")
+                error = body.get("error")
+                if error:
+                    if error == "authorization_pending":
+                        continue
+                    elif error == "slow_down":
+                        poll_interval += 5
+                        continue
+                    elif error == "access_denied":
+                        raise AuthenticationError("Authorization denied by user")
+                    elif error == "expired_token":
+                        raise AuthenticationError("Device code expired")
+                    else:
+                        desc = body.get("error_description", "")
+                        raise AuthenticationError(f"Token error: {error} — {desc}")
 
-            if body.get("access_token"):
-                return body
+                if body.get("access_token"):
+                    return body
 
         raise AuthenticationError("Device code expired (polling deadline reached)")
 
@@ -202,7 +206,8 @@ class OAuthManager:
             "client_id": self.config.oauth_client_id,
         }
 
-        response = httpx.post(url, data=data, timeout=15)
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, data=data, timeout=15)
 
         try:
             body = response.json()

--- a/src/kion_mcp/config/settings.py
+++ b/src/kion_mcp/config/settings.py
@@ -24,6 +24,8 @@ class KionConfig:
         self.server_base_url: Optional[str] = None
         self.bearer_token: Optional[str] = None
         self.auth_script_path: Optional[str] = None
+        self.oauth_client_id: Optional[str] = None
+        self.oauth_scopes: str = "openid offline_access"
         self._config_path: Optional[str] = None
         self._loaded_from_env: bool = False
     
@@ -64,6 +66,8 @@ class KionConfig:
             self.server_base_url = self._process_server_url(server_url)
             self.bearer_token = bearer_token
             self.auth_script_path = None  #Auth script not used in DXT mode
+            self.oauth_client_id = os.getenv('KION_OAUTH_CLIENT_ID')
+            self.oauth_scopes = os.getenv('KION_OAUTH_SCOPES', 'openid offline_access')
             self._loaded_from_env = True
             
             logging.info("Configuration loaded from environment variables (DXT mode)")
@@ -110,6 +114,8 @@ class KionConfig:
             raw_server_url = config_data.get('server_base_url')
             self.bearer_token = config_data.get('bearer_token')
             self.auth_script_path = config_data.get('auth_script_path')
+            self.oauth_client_id = config_data.get('oauth_client_id')
+            self.oauth_scopes = config_data.get('oauth_scopes', 'openid offline_access')
             
             # Only process URL if it's not a placeholder
             if raw_server_url and not self._is_placeholder_value('server_base_url', raw_server_url):
@@ -165,7 +171,10 @@ class KionConfig:
             config_data['bearer_token'] = self.bearer_token
         if self.auth_script_path:
             config_data['auth_script_path'] = self.auth_script_path
-        
+        if self.oauth_client_id:
+            config_data['oauth_client_id'] = self.oauth_client_id
+            config_data['oauth_scopes'] = self.oauth_scopes
+
         try:
             with open(self._config_path, 'w') as f:
                 yaml.safe_dump(config_data, f, default_flow_style=False)
@@ -206,8 +215,12 @@ class KionConfig:
         return server_url and not self._is_placeholder_value('server_base_url', server_url)
     
     def needs_configuration(self) -> bool:
-        """Check if configuration needs setup (only checks server URL)."""
-        return not self.has_real_server_url()
+        """Check if configuration needs setup (checks server URL and auth method)."""
+        if not self.has_real_server_url():
+            return True
+        if self.is_oauth_mode():
+            return False
+        return not self.has_real_bearer() and not self.has_auth_script()
     
     def is_script_auth_mode(self) -> bool:
         """Check if using script-based authentication."""
@@ -224,6 +237,10 @@ class KionConfig:
     def has_auth_script(self) -> bool:
         """Check if we have a configured auth script."""
         return self.auth_script_path and self.auth_script_path.strip()
+
+    def is_oauth_mode(self) -> bool:
+        """Check if using OAuth authentication."""
+        return bool(self.oauth_client_id and self.oauth_client_id.strip())
     
     def create_placeholder_config(self) -> str:
         """Create a placeholder config file in the script directory."""

--- a/src/kion_mcp/config/settings.py
+++ b/src/kion_mcp/config/settings.py
@@ -245,15 +245,20 @@ class KionConfig:
     def create_placeholder_config(self) -> str:
         """Create a placeholder config file in the script directory."""
         config_path = Path(__file__).parent.parent.parent.parent / 'kion_mcp_config.yaml'
-        
-        config_data = {
-            'server_base_url': PLACEHOLDER_VALUES['server_base_url'],
-            'bearer_token': PLACEHOLDER_VALUES['bearer_token']
-        }
-        
+
+        # Write raw YAML with comments (yaml.safe_dump doesn't support comments)
+        placeholder_content = (
+            f"server_base_url: {PLACEHOLDER_VALUES['server_base_url']}\n"
+            f"bearer_token: {PLACEHOLDER_VALUES['bearer_token']}\n"
+            "\n"
+            "# OAuth authentication (alternative to bearer_token)\n"
+            "# oauth_client_id: your_oauth_client_id_here\n"
+            "# oauth_scopes: openid offline_access\n"
+        )
+
         try:
             with open(config_path, 'w') as f:
-                yaml.safe_dump(config_data, f, default_flow_style=False)
+                f.write(placeholder_content)
             logging.info(f"Placeholder configuration created at: {config_path.resolve()}")
             self._config_path = config_path
             return str(config_path.resolve())

--- a/src/kion_mcp/interaction/elicitation.py
+++ b/src/kion_mcp/interaction/elicitation.py
@@ -50,6 +50,29 @@ async def elicit_bearer_token(ctx: Context) -> Tuple[bool, str]:
         return False, ""
 
 
+async def elicit_device_code_approval(ctx: Context, user_code: str, verification_url: str) -> bool:
+    """Show the OAuth device code and verification URL to the user.
+    Returns True if the user acknowledged, False if elicitation failed.
+    """
+    message = (
+        f"To authenticate with Kion, please visit the following URL and enter the code shown below.\n\n"
+        f"URL: {verification_url}\n"
+        f"Code: {user_code}\n\n"
+        f"A browser window may have been opened for you. "
+        f"After approving in the browser, click 'Accept' to continue."
+    )
+    try:
+        result = await ctx.elicit(message, response_type=None)
+        match result:
+            case AcceptedElicitation():
+                return True
+            case DeclinedElicitation() | CancelledElicitation():
+                return False
+    except Exception as e:
+        logging.debug(f"Device code elicitation failed: {e}")
+        return False
+
+
 async def elicit_financial_operation_approval(ctx: Context, operation_type: str, request_data: dict) -> bool:
     """
     Elicit user approval for financial operations like funding source creation and allocation.

--- a/src/kion_mcp/interaction/elicitation.py
+++ b/src/kion_mcp/interaction/elicitation.py
@@ -73,6 +73,53 @@ async def elicit_device_code_approval(ctx: Context, user_code: str, verification
         return False
 
 
+async def elicit_auth_method(ctx: Context) -> tuple[bool, str]:
+    """Elicit preferred authentication method from user.
+    Returns (success, method) where method is one of: 'bearer_token', 'oauth', 'auth_script'
+    """
+    message = (
+        "How would you like to authenticate with Kion?\n\n"
+        "1. Bearer Token - Enter a static API key\n"
+        "2. OAuth (Device Flow) - Authenticate via browser (recommended)\n"
+        "3. Auth Script - Use a custom script to provide tokens\n\n"
+        "Enter 1, 2, or 3:"
+    )
+    try:
+        result = await ctx.elicit(message, response_type=str)
+        match result:
+            case AcceptedElicitation(data=choice):
+                choice = choice.strip()
+                if choice in ("2", "oauth", "OAuth"):
+                    return True, "oauth"
+                elif choice in ("3", "script", "auth_script"):
+                    return True, "auth_script"
+                else:
+                    return True, "bearer_token"
+            case DeclinedElicitation() | CancelledElicitation():
+                return False, ""
+    except Exception as e:
+        logging.debug(f"Auth method elicitation failed: {e}")
+        return False, ""
+
+
+async def elicit_oauth_client_id(ctx: Context) -> tuple[bool, str]:
+    """Elicit OAuth client ID from user."""
+    try:
+        result = await ctx.elicit(
+            "Enter the OAuth Client ID for your Kion instance. "
+            "You can find this in Kion under System Administration > OAuth Clients.",
+            response_type=str,
+        )
+        match result:
+            case AcceptedElicitation(data=client_id):
+                return True, client_id
+            case DeclinedElicitation() | CancelledElicitation():
+                return False, ""
+    except Exception as e:
+        logging.debug(f"OAuth client ID elicitation failed: {e}")
+        return False, ""
+
+
 async def elicit_financial_operation_approval(ctx: Context, operation_type: str, request_data: dict) -> bool:
     """
     Elicit user approval for financial operations like funding source creation and allocation.

--- a/src/kion_mcp/server_management/tool_manager.py
+++ b/src/kion_mcp/server_management/tool_manager.py
@@ -209,7 +209,14 @@ def setup_authentication_and_middleware(mcp: FastMCP, config=None, auth_manager=
     
     # Set up authentication and middleware
     mcp._client.base_url = config.server_base_url
-    mcp._client.headers = build_standard_headers(auth_manager.get_bearer_token())
+    try:
+        token = auth_manager.get_bearer_token()
+        mcp._client.headers = build_standard_headers(token)
+    except Exception as e:
+        # OAuth first-run or auth not ready — set minimal headers.
+        # The 401 middleware will trigger auth refresh on first API call.
+        logging.warning(f"Could not get initial bearer token: {e}")
+        mcp._client.headers = build_standard_headers("")
     
     auth_middleware = AuthenticationMiddleware(config, auth_manager, mcp)
     mcp.add_middleware(auth_middleware)

--- a/src/kion_mcp/tools/config_tool.py
+++ b/src/kion_mcp/tools/config_tool.py
@@ -2,63 +2,118 @@
 
 import logging
 from fastmcp import Context
-from ..interaction.elicitation import elicit_kion_url, elicit_bearer_token
+from ..interaction.elicitation import (
+    elicit_kion_url,
+    elicit_bearer_token,
+    elicit_auth_method,
+    elicit_oauth_client_id,
+)
 from ..config.settings import KionConfig
+from ..config.oauth import OAuthManager
 from ..exceptions import ConfigurationError
 
 
 async def setup_kion_config_impl(ctx: Context) -> str:
     """Setup Kion MCP Server configuration.
-    
+
     Collects Kion instance URL and authentication details needed to connect.
     Must be called before any other Kion functionality is available.
-    
+
     Args:
         ctx: FastMCP context for user interaction
-        
+
     Returns:
         str: Configuration status message
     """
     logging.info("Starting Kion configuration setup")
-    # Load existing config if it exists (may have placeholders)
     try:
         config = KionConfig.load()
     except Exception:
         config = KionConfig()
-    
+
     # Try to elicit Kion URL
     url_result = await elicit_kion_url(ctx)
-    
+
     if url_result is None:
-        # Treat None as elicitation not supported
         url_success, kion_url = False, ""
     else:
         url_success, kion_url = url_result
-    
+
     if url_success and kion_url.strip():
         config.server_base_url = config._process_server_url(kion_url.strip())
         logging.info(f"Successfully collected Kion URL: {kion_url}")
-        
-        # Try to elicit bearer token
-        token_result = await elicit_bearer_token(ctx)
-        
-        if token_result is None:
-            # Treat None as elicitation not supported
-            token_success, bearer_token = False, ""
+
+        # Ask for auth method
+        method_success, auth_method = await elicit_auth_method(ctx)
+
+        if method_success and auth_method == "oauth":
+            # OAuth flow
+            client_id_success, client_id = await elicit_oauth_client_id(ctx)
+            if client_id_success and client_id.strip():
+                config.oauth_client_id = client_id.strip()
+                config.bearer_token = None
+                config.save()
+
+                # Run device flow to validate
+                oauth_mgr = OAuthManager(config)
+                success, token_or_msg = await oauth_mgr.run_device_flow(ctx)
+
+                if success:
+                    return f"""
+✅ Configuration completed successfully!
+
+Created kion_mcp_config.yaml with:
+- Kion URL: {config.server_base_url}
+- Authentication: OAuth Device Flow (client_id: {config.oauth_client_id})
+
+OAuth token cached. All Kion API tools should now be available.
+NOTE: YOU WILL NOT BE ABLE TO CALL `check_config_status` after this point, that tool is no longer active. If you don't see the complete list of tools immediately return to the user and tell them that the server should now be setup and you should have access to everything after their next message. Only if you still see the config tools then tell them to restart the client.
+"""
+                else:
+                    return f"""
+⚠️ Partial configuration completed.
+
+Created kion_mcp_config.yaml with:
+- Kion URL: {config.server_base_url}
+- OAuth Client ID: {config.oauth_client_id}
+
+OAuth device flow failed: {token_or_msg}
+The configuration has been saved. On next restart, the server will attempt OAuth authentication again.
+"""
+            else:
+                return "❌ OAuth Client ID is required for OAuth authentication."
+
+        elif method_success and auth_method == "auth_script":
+            return f"""
+⚠️ Partial configuration completed.
+
+Created kion_mcp_config.yaml with:
+- Kion URL: {config.server_base_url}
+
+To complete setup, add the following to your kion_mcp_config.yaml:
+auth_script_path: /path/to/your/auth/script.sh
+
+The script should output a valid bearer token to stdout.
+"""
+
         else:
-            token_success, bearer_token = token_result
-        
-        if token_success and bearer_token.strip():
-            config.bearer_token = bearer_token.strip()
-            logging.info("Successfully collected bearer token")
-        # Preserve existing valid bearer token if elicitation failed/skipped
-        
-        # Save config file with whatever we collected
-        try:
-            config.save()
-            
-            if config.bearer_token:
-                return f"""
+            # Bearer token flow (default / original behavior)
+            token_result = await elicit_bearer_token(ctx)
+
+            if token_result is None:
+                token_success, bearer_token = False, ""
+            else:
+                token_success, bearer_token = token_result
+
+            if token_success and bearer_token.strip():
+                config.bearer_token = bearer_token.strip()
+                logging.info("Successfully collected bearer token")
+
+            try:
+                config.save()
+
+                if config.bearer_token:
+                    return f"""
 ✅ Configuration completed successfully!
 
 Created kion_mcp_config.yaml with:
@@ -68,8 +123,8 @@ Created kion_mcp_config.yaml with:
 All Kion API tools should now be available. If you don't see them immediately, ask the user to send another message and they should appear.
 NOTE: YOU WILL NOT BE ABLE TO CALL `check_config_status` after this point, that tool is no longer active. If you don't see the complete list of tools immediately return to the user and tell them that the server should now be setup and you should have access to everything after their next message. Only if you still see the config tools then tell them to restart the client.
 """
-            else:
-                return f"""
+                else:
+                    return f"""
 ⚠️ Partial configuration completed.
 
 Created kion_mcp_config.yaml with:
@@ -85,13 +140,12 @@ bearer_token: your_bearer_token_here
 Once they have completed this they will need to restart the MCP client that you are running in order to access Kion functionality.
 Instruct them through this process, you are not able to update the file yourself.
 """
-                
-        except Exception as e:
-            logging.error(f"Failed to create config file: {e}")
-            return f"❌ Error creating config file: {e}"
-    
+
+            except Exception as e:
+                logging.error(f"Failed to create config file: {e}")
+                return f"❌ Error creating config file: {e}"
+
     else:
-        # Fallback guidance when elicitation doesn't work - point to existing placeholder file
         from pathlib import Path
         script_dir_path = (Path(__file__).parent.parent.parent.parent / 'kion_mcp_config.yaml').resolve()
         home_dir_path = (Path.home() / 'kion_mcp_config.yaml').resolve()
@@ -109,7 +163,13 @@ server_base_url: https://their-kion-instance.com
 bearer_token: their_bearer_token_here
 ```
 
-The user can get the bearer token by going to their Kion instance, clicking their user icon in the top right corner, then 'App API Keys', and then 'Add +'. 
+Alternatively, for OAuth authentication:
+```yaml
+server_base_url: https://their-kion-instance.com
+oauth_client_id: their_oauth_client_id_here
+```
+
+The user can get a bearer token by going to their Kion instance, clicking their user icon in the top right corner, then 'App API Keys', and then 'Add +'.
 
 Once they have updated the placeholder values, they will need to tell you so that you can call the `check_config_status` tool to activate the Kion API tools.
 You are not able to update the file yourself, you can only instruct the user through this process.
@@ -117,54 +177,44 @@ You are not able to update the file yourself, you can only instruct the user thr
 
 
 async def check_config_status_impl(ctx: Context) -> str:
-    """Check if the Kion configuration is now valid and ready for use.
-    
-    This tool checks if the configuration file has been properly set up
-    and can be used to connect to Kion. If the configuration is valid,
-    the server will automatically enable the Kion API tools.
-    
-    Args:
-        ctx: FastMCP context for user interaction
-        
-    Returns:
-        str: Configuration status message
-    """
+    """Check if the Kion configuration is now valid and ready for use."""
     logging.info("Checking Kion configuration status")
     try:
         config = KionConfig.load()
-        
+
         if config.needs_configuration():
-            # Config still needs server URL
             return """
 ❌ Configuration incomplete: Kion server URL not configured.
 
 Please update your kion_mcp_config.yaml file with your actual Kion instance URL.
 """
-        
-        # Check if we have valid authentication (either bearer token or auth script)
+
         has_bearer = config.has_real_bearer()
         has_auth_script = config.has_auth_script()
-        
-        if not has_bearer and not has_auth_script:
+        has_oauth = config.is_oauth_mode()
+
+        if not has_bearer and not has_auth_script and not has_oauth:
             return """
 ❌ Configuration incomplete: Authentication not configured.
 
-Please update your kion_mcp_config.yaml file with a valid bearer token.
-You can get a bearer token from your Kion instance by clicking your user icon 
-in the top right corner, then 'App API Keys', and then 'Add +'.
+Please update your kion_mcp_config.yaml file with one of:
+- bearer_token: your_api_key_here
+- oauth_client_id: your_client_id_here
+- auth_script_path: /path/to/script.sh
 """
-        
-        # Config looks complete
+
+        auth_method = "OAuth" if has_oauth else ("Auth Script" if has_auth_script else "Bearer Token")
         logging.info("Configuration check passed - server should transition to operational mode")
-        return """
+        return f"""
 ✅ Configuration is valid!
 
 Your Kion MCP Server configuration is complete and ready to use.
+Authentication method: {auth_method}
 The server has automatically enabled all available Kion API tools.
 
 If you don't see the tools now, please ask the user to send another message which should refresh the tool list visible to you. If the tools still don't appear after the user sends a follow-up message, instruct the user to restart whatever application you are running in (Claude Desktop, VS Code, etc.) to refresh the MCP tool definitions.
 """
-            
+
     except ConfigurationError as e:
         return f"""
 ❌ Configuration error: {e}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Shared test fixtures for kion-mcp tests."""
+
+import pytest
+from kion_mcp.config.settings import KionConfig
+
+
+@pytest.fixture
+def base_config():
+    """Create a KionConfig with minimal valid settings."""
+    config = KionConfig()
+    config.server_base_url = "https://kion.example.com/api"
+    return config
+
+
+@pytest.fixture
+def oauth_config(base_config):
+    """Create a KionConfig with OAuth settings."""
+    base_config.oauth_client_id = "test-client-id"
+    base_config.oauth_scopes = "openid offline_access"
+    return base_config
+
+
+@pytest.fixture
+def bearer_config(base_config):
+    """Create a KionConfig with a static bearer token."""
+    base_config.bearer_token = "test-bearer-token"
+    return base_config
+
+
+@pytest.fixture
+def script_config(base_config):
+    """Create a KionConfig with an auth script."""
+    base_config.auth_script_path = "/usr/local/bin/get-token.sh"
+    return base_config

--- a/tests/test_auth_priority.py
+++ b/tests/test_auth_priority.py
@@ -1,0 +1,68 @@
+"""Tests for AuthManager OAuth integration and priority chain."""
+
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+from kion_mcp.config.auth import AuthManager
+from kion_mcp.config.oauth import OAuthManager
+from kion_mcp.exceptions import AuthenticationError
+
+
+class TestAuthPriority:
+    """Test auth method priority: bearer > OAuth > script."""
+
+    def test_bearer_token_wins_over_oauth(self, base_config):
+        base_config.bearer_token = "static-token"
+        base_config.oauth_client_id = "client-id"
+        mgr = AuthManager(base_config)
+        token = mgr.get_bearer_token()
+        assert token == "static-token"
+
+    def test_oauth_used_when_no_bearer(self, oauth_config):
+        oauth_config.bearer_token = None
+        mgr = AuthManager(oauth_config)
+        with patch.object(OAuthManager, 'get_access_token', new_callable=AsyncMock, return_value="oauth-token"):
+            # get_bearer_token is sync, but OAuth is async — the sync path
+            # should return None so that async callers use get_bearer_token_async
+            # For now, verify the OAuthManager is created
+            assert mgr._oauth_manager is not None
+
+    def test_script_auth_used_when_no_oauth(self, script_config):
+        mgr = AuthManager(script_config)
+        assert mgr._oauth_manager is None
+        # Script auth tested elsewhere
+
+    def test_no_oauth_manager_without_client_id(self, base_config):
+        mgr = AuthManager(base_config)
+        assert mgr._oauth_manager is None
+
+
+class TestAuthManagerOAuthRefresh:
+    """Test refresh_bearer_token_with_elicitation with OAuth."""
+
+    @pytest.mark.asyncio
+    async def test_oauth_refresh_delegates_to_oauth_manager(self, oauth_config):
+        oauth_config.bearer_token = None
+        mgr = AuthManager(oauth_config)
+        with patch.object(mgr._oauth_manager, 'refresh_access_token', new_callable=AsyncMock, return_value=(True, "refreshed")):
+            success, token = await mgr.refresh_bearer_token_with_elicitation()
+            assert success is True
+            assert token == "refreshed"
+
+    @pytest.mark.asyncio
+    async def test_oauth_refresh_falls_back_to_device_flow(self, oauth_config):
+        oauth_config.bearer_token = None
+        mgr = AuthManager(oauth_config)
+        with patch.object(mgr._oauth_manager, 'refresh_access_token', new_callable=AsyncMock, return_value=(False, "expired")):
+            with patch.object(mgr._oauth_manager, 'run_device_flow', new_callable=AsyncMock, return_value=(True, "device-token")):
+                success, token = await mgr.refresh_bearer_token_with_elicitation()
+                assert success is True
+                assert token == "device-token"
+
+    @pytest.mark.asyncio
+    async def test_oauth_refresh_returns_failure_when_all_fail(self, oauth_config):
+        oauth_config.bearer_token = None
+        mgr = AuthManager(oauth_config)
+        with patch.object(mgr._oauth_manager, 'refresh_access_token', new_callable=AsyncMock, return_value=(False, "expired")):
+            with patch.object(mgr._oauth_manager, 'run_device_flow', new_callable=AsyncMock, return_value=(False, "denied")):
+                success, msg = await mgr.refresh_bearer_token_with_elicitation()
+                assert success is False

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,74 @@
+"""Tests for OAuthManager."""
+
+import json
+import time
+import pytest
+from pathlib import Path
+from unittest.mock import patch, AsyncMock, MagicMock
+from kion_mcp.config.oauth import OAuthManager
+
+
+class TestTokenCache:
+    """Test token cache file operations."""
+
+    def test_save_and_load_token_cache(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            mgr._save_token_cache(
+                access_token="access123",
+                refresh_token="refresh456",
+                access_expires_in=3600,
+            )
+            cache = mgr._load_token_cache()
+            assert cache is not None
+            assert cache["access_token"] == "access123"
+            assert cache["refresh_token"] == "refresh456"
+            assert cache["server_url"] == "https://kion.example.com/api"
+
+    def test_load_cache_returns_none_when_missing(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            assert mgr._load_token_cache() is None
+
+    def test_load_cache_returns_none_on_server_url_mismatch(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        cache_file.write_text(json.dumps({
+            "server_url": "https://other-kion.example.com/api",
+            "access_token": "old-token",
+            "access_token_expires_at": time.time() + 3600,
+            "refresh_token": "old-refresh",
+            "refresh_token_expires_at": time.time() + 86400,
+        }))
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            assert mgr._load_token_cache() is None
+
+    def test_load_cache_returns_none_on_corrupt_file(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        cache_file.write_text("not valid json{{{")
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            assert mgr._load_token_cache() is None
+
+    def test_is_token_expired_false_for_future(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        assert mgr._is_token_expired(time.time() + 3600) is False
+
+    def test_is_token_expired_true_for_past(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        assert mgr._is_token_expired(time.time() - 10) is True
+
+    def test_is_token_expired_true_within_buffer(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        # 15 seconds from now is within 30-second buffer
+        assert mgr._is_token_expired(time.time() + 15) is True
+
+    def test_clear_cached_tokens(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        cache_file.write_text("{}")
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            mgr.clear_cached_tokens()
+            assert not cache_file.exists()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -9,6 +9,24 @@ from kion_mcp.config.oauth import OAuthManager
 from kion_mcp.exceptions import AuthenticationError
 
 
+def _mock_async_client(*responses):
+    """Create a mock httpx.AsyncClient context manager that returns canned responses.
+
+    Each call to client.post() returns the next response in the list.
+    If only one response is provided, it's returned for every call.
+    """
+    mock_client = AsyncMock()
+    if len(responses) == 1:
+        mock_client.post.return_value = responses[0]
+    else:
+        mock_client.post.side_effect = list(responses)
+
+    cm = AsyncMock()
+    cm.__aenter__.return_value = mock_client
+    cm.__aexit__.return_value = False
+    return cm, mock_client
+
+
 class TestTokenCache:
     """Test token cache file operations."""
 
@@ -74,6 +92,17 @@ class TestTokenCache:
             mgr.clear_cached_tokens()
             assert not cache_file.exists()
 
+    def test_cache_file_permissions(self, tmp_path, oauth_config):
+        """Token cache file should be readable only by the owner (0600)."""
+        import os
+        import stat
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            mgr._save_token_cache("tok", "ref", 3600)
+            mode = os.stat(cache_file).st_mode
+            assert stat.S_IMODE(mode) == 0o600
+
 
 class TestDeviceFlow:
     """Test device authorization request and token polling."""
@@ -91,7 +120,8 @@ class TestDeviceFlow:
             "expires_in": 900,
             "interval": 5,
         }
-        with patch("httpx.post", return_value=mock_response):
+        cm, _ = _mock_async_client(mock_response)
+        with patch("httpx.AsyncClient", return_value=cm):
             result = await mgr._request_device_authorization()
             assert result["device_code"] == "device123"
             assert result["user_code"] == "ABCD-EFGH"
@@ -102,7 +132,8 @@ class TestDeviceFlow:
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_response.text = "Not Found"
-        with patch("httpx.post", return_value=mock_response):
+        cm, _ = _mock_async_client(mock_response)
+        with patch("httpx.AsyncClient", return_value=cm):
             with pytest.raises(AuthenticationError, match="OAuth is not enabled"):
                 await mgr._request_device_authorization()
 
@@ -115,7 +146,8 @@ class TestDeviceFlow:
             "error": "invalid_client",
             "error_description": "Unknown client ID",
         }
-        with patch("httpx.post", return_value=mock_response):
+        cm, _ = _mock_async_client(mock_response)
+        with patch("httpx.AsyncClient", return_value=cm):
             with pytest.raises(AuthenticationError, match="invalid_client"):
                 await mgr._request_device_authorization()
 
@@ -135,7 +167,8 @@ class TestDeviceFlow:
             "refresh_token": "refresh-token-456",
         }
 
-        with patch("httpx.post", side_effect=[pending_response, success_response]):
+        cm, _ = _mock_async_client(pending_response, success_response)
+        with patch("httpx.AsyncClient", return_value=cm):
             with patch("asyncio.sleep", new_callable=AsyncMock):
                 result = await mgr._poll_for_token("device123", interval=5, expires_in=900)
                 assert result["access_token"] == "access-token-123"
@@ -148,7 +181,8 @@ class TestDeviceFlow:
         denied_response.status_code = 400
         denied_response.json.return_value = {"error": "access_denied"}
 
-        with patch("httpx.post", return_value=denied_response):
+        cm, _ = _mock_async_client(denied_response)
+        with patch("httpx.AsyncClient", return_value=cm):
             with patch("asyncio.sleep", new_callable=AsyncMock):
                 with pytest.raises(AuthenticationError, match="denied"):
                     await mgr._poll_for_token("device123", interval=5, expires_in=900)
@@ -160,7 +194,8 @@ class TestDeviceFlow:
         expired_response.status_code = 400
         expired_response.json.return_value = {"error": "expired_token"}
 
-        with patch("httpx.post", return_value=expired_response):
+        cm, _ = _mock_async_client(expired_response)
+        with patch("httpx.AsyncClient", return_value=cm):
             with patch("asyncio.sleep", new_callable=AsyncMock):
                 with pytest.raises(AuthenticationError, match="expired"):
                     await mgr._poll_for_token("device123", interval=5, expires_in=900)
@@ -180,8 +215,9 @@ class TestDeviceFlow:
             "expires_in": 3600,
         }
 
+        cm, mock_client = _mock_async_client(slow_response, success_response)
         sleep_mock = AsyncMock()
-        with patch("httpx.post", side_effect=[slow_response, success_response]):
+        with patch("httpx.AsyncClient", return_value=cm):
             with patch("asyncio.sleep", sleep_mock):
                 result = await mgr._poll_for_token("device123", interval=5, expires_in=900)
                 # First sleep should be 5s (original), second should be 10s (5+5 slow_down)
@@ -211,9 +247,10 @@ class TestTokenRefresh:
             "refresh_token": "new-refresh-token",
         }
 
+        cm, _ = _mock_async_client(success_response)
         with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
             mgr = OAuthManager(oauth_config)
-            with patch("httpx.post", return_value=success_response):
+            with patch("httpx.AsyncClient", return_value=cm):
                 success, token = await mgr.refresh_access_token()
                 assert success is True
                 assert token == "new-access-token"
@@ -256,9 +293,10 @@ class TestTokenRefresh:
         error_response.status_code = 400
         error_response.json.return_value = {"error": "invalid_grant"}
 
+        cm, _ = _mock_async_client(error_response)
         with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
             mgr = OAuthManager(oauth_config)
-            with patch("httpx.post", return_value=error_response):
+            with patch("httpx.AsyncClient", return_value=cm):
                 success, msg = await mgr.refresh_access_token()
                 assert success is False
 
@@ -330,9 +368,10 @@ class TestGetAccessToken:
             "refresh_token": "new-refresh",
         }
 
+        cm, _ = _mock_async_client(refresh_response)
         with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
             mgr = OAuthManager(oauth_config)
-            with patch("httpx.post", return_value=refresh_response):
+            with patch("httpx.AsyncClient", return_value=cm):
                 token = await mgr.get_access_token()
                 assert token == "refreshed-token"
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -27,6 +27,29 @@ def _mock_async_client(*responses):
     return cm, mock_client
 
 
+class TestOAuthUrl:
+    """Test OAuth URL construction."""
+
+    def test_strips_api_suffix(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        assert mgr._oauth_url("/token") == "https://kion.example.com/token"
+
+    def test_strips_api_suffix_with_trailing_slash(self, oauth_config):
+        oauth_config.server_base_url = "https://kion.example.com/api/"
+        mgr = OAuthManager(oauth_config)
+        assert mgr._oauth_url("/token") == "https://kion.example.com/token"
+
+    def test_no_api_suffix(self, oauth_config):
+        oauth_config.server_base_url = "https://kion.example.com"
+        mgr = OAuthManager(oauth_config)
+        assert mgr._oauth_url("/device_authorization") == "https://kion.example.com/device_authorization"
+
+    def test_localhost_with_port(self, oauth_config):
+        oauth_config.server_base_url = "http://localhost:8081"
+        mgr = OAuthManager(oauth_config)
+        assert mgr._oauth_url("/token") == "http://localhost:8081/token"
+
+
 class TestTokenCache:
     """Test token cache file operations."""
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -6,6 +6,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, AsyncMock, MagicMock
 from kion_mcp.config.oauth import OAuthManager
+from kion_mcp.exceptions import AuthenticationError
 
 
 class TestTokenCache:
@@ -72,3 +73,285 @@ class TestTokenCache:
             mgr = OAuthManager(oauth_config)
             mgr.clear_cached_tokens()
             assert not cache_file.exists()
+
+
+class TestDeviceFlow:
+    """Test device authorization request and token polling."""
+
+    @pytest.mark.asyncio
+    async def test_request_device_authorization_success(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "device_code": "device123",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://kion.example.com/oauth/device",
+            "verification_uri_complete": "https://kion.example.com/oauth/device?user_code=ABCD-EFGH",
+            "expires_in": 900,
+            "interval": 5,
+        }
+        with patch("httpx.post", return_value=mock_response):
+            result = await mgr._request_device_authorization()
+            assert result["device_code"] == "device123"
+            assert result["user_code"] == "ABCD-EFGH"
+
+    @pytest.mark.asyncio
+    async def test_request_device_authorization_404_oauth_not_enabled(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        with patch("httpx.post", return_value=mock_response):
+            with pytest.raises(AuthenticationError, match="OAuth is not enabled"):
+                await mgr._request_device_authorization()
+
+    @pytest.mark.asyncio
+    async def test_request_device_authorization_error_response(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {
+            "error": "invalid_client",
+            "error_description": "Unknown client ID",
+        }
+        with patch("httpx.post", return_value=mock_response):
+            with pytest.raises(AuthenticationError, match="invalid_client"):
+                await mgr._request_device_authorization()
+
+    @pytest.mark.asyncio
+    async def test_poll_for_token_success_after_pending(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        pending_response = MagicMock()
+        pending_response.status_code = 400
+        pending_response.json.return_value = {"error": "authorization_pending"}
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "access_token": "access-token-123",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "refresh-token-456",
+        }
+
+        with patch("httpx.post", side_effect=[pending_response, success_response]):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await mgr._poll_for_token("device123", interval=5, expires_in=900)
+                assert result["access_token"] == "access-token-123"
+                assert result["refresh_token"] == "refresh-token-456"
+
+    @pytest.mark.asyncio
+    async def test_poll_for_token_access_denied(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        denied_response = MagicMock()
+        denied_response.status_code = 400
+        denied_response.json.return_value = {"error": "access_denied"}
+
+        with patch("httpx.post", return_value=denied_response):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(AuthenticationError, match="denied"):
+                    await mgr._poll_for_token("device123", interval=5, expires_in=900)
+
+    @pytest.mark.asyncio
+    async def test_poll_for_token_expired(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        expired_response = MagicMock()
+        expired_response.status_code = 400
+        expired_response.json.return_value = {"error": "expired_token"}
+
+        with patch("httpx.post", return_value=expired_response):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(AuthenticationError, match="expired"):
+                    await mgr._poll_for_token("device123", interval=5, expires_in=900)
+
+    @pytest.mark.asyncio
+    async def test_poll_for_token_slow_down(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        slow_response = MagicMock()
+        slow_response.status_code = 400
+        slow_response.json.return_value = {"error": "slow_down"}
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "access_token": "access-token-123",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+
+        sleep_mock = AsyncMock()
+        with patch("httpx.post", side_effect=[slow_response, success_response]):
+            with patch("asyncio.sleep", sleep_mock):
+                result = await mgr._poll_for_token("device123", interval=5, expires_in=900)
+                # First sleep should be 5s (original), second should be 10s (5+5 slow_down)
+                assert sleep_mock.call_args_list[1][0][0] == 10
+
+
+class TestTokenRefresh:
+    """Test refresh token exchange."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_access_token_success(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        cache_file.write_text(json.dumps({
+            "server_url": "https://kion.example.com/api",
+            "access_token": "old-access",
+            "access_token_expires_at": time.time() - 100,
+            "refresh_token": "valid-refresh",
+            "refresh_token_expires_at": time.time() + 86400,
+        }))
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "access_token": "new-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "new-refresh-token",
+        }
+
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            with patch("httpx.post", return_value=success_response):
+                success, token = await mgr.refresh_access_token()
+                assert success is True
+                assert token == "new-access-token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_access_token_no_refresh_token(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            success, msg = await mgr.refresh_access_token()
+            assert success is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_access_token_expired_refresh(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        cache_file.write_text(json.dumps({
+            "server_url": "https://kion.example.com/api",
+            "access_token": "old-access",
+            "access_token_expires_at": time.time() - 100,
+            "refresh_token": "expired-refresh",
+            "refresh_token_expires_at": time.time() - 100,
+        }))
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            success, msg = await mgr.refresh_access_token()
+            assert success is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_access_token_server_error(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        cache_file.write_text(json.dumps({
+            "server_url": "https://kion.example.com/api",
+            "access_token": "old-access",
+            "access_token_expires_at": time.time() - 100,
+            "refresh_token": "valid-refresh",
+            "refresh_token_expires_at": time.time() + 86400,
+        }))
+
+        error_response = MagicMock()
+        error_response.status_code = 400
+        error_response.json.return_value = {"error": "invalid_grant"}
+
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            with patch("httpx.post", return_value=error_response):
+                success, msg = await mgr.refresh_access_token()
+                assert success is False
+
+
+class TestBrowserAndElicitation:
+    """Test browser launch and device code elicitation."""
+
+    def test_open_browser_attempts_open_on_darwin(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        with patch("platform.system", return_value="Darwin"):
+            with patch("subprocess.Popen") as mock_popen:
+                mock_popen.return_value.poll.return_value = None
+                result = mgr._open_browser("https://example.com/oauth/device?code=ABCD")
+                mock_popen.assert_called_once()
+                assert "open" in mock_popen.call_args[0][0]
+
+    def test_open_browser_attempts_xdg_open_on_linux(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        with patch("platform.system", return_value="Linux"):
+            with patch("subprocess.Popen") as mock_popen:
+                mock_popen.return_value.poll.return_value = None
+                result = mgr._open_browser("https://example.com/oauth/device?code=ABCD")
+                mock_popen.assert_called_once()
+                assert "xdg-open" in mock_popen.call_args[0][0]
+
+    def test_open_browser_returns_false_on_error(self, oauth_config):
+        mgr = OAuthManager(oauth_config)
+        with patch("platform.system", return_value="Darwin"):
+            with patch("subprocess.Popen", side_effect=OSError("no browser")):
+                result = mgr._open_browser("https://example.com")
+                assert result is False
+
+
+class TestGetAccessToken:
+    """Test the main get_access_token entry point."""
+
+    @pytest.mark.asyncio
+    async def test_returns_cached_valid_token(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        cache_file.write_text(json.dumps({
+            "server_url": "https://kion.example.com/api",
+            "access_token": "cached-token",
+            "access_token_expires_at": time.time() + 3600,
+            "refresh_token": "refresh",
+            "refresh_token_expires_at": time.time() + 86400,
+        }))
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            token = await mgr.get_access_token()
+            assert token == "cached-token"
+
+    @pytest.mark.asyncio
+    async def test_refreshes_expired_token(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        cache_file.write_text(json.dumps({
+            "server_url": "https://kion.example.com/api",
+            "access_token": "expired-token",
+            "access_token_expires_at": time.time() - 100,
+            "refresh_token": "valid-refresh",
+            "refresh_token_expires_at": time.time() + 86400,
+        }))
+
+        refresh_response = MagicMock()
+        refresh_response.status_code = 200
+        refresh_response.json.return_value = {
+            "access_token": "refreshed-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "new-refresh",
+        }
+
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            with patch("httpx.post", return_value=refresh_response):
+                token = await mgr.get_access_token()
+                assert token == "refreshed-token"
+
+    @pytest.mark.asyncio
+    async def test_falls_through_to_device_flow(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        # No cache file — should trigger device flow
+
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            with patch.object(mgr, 'run_device_flow', new_callable=AsyncMock, return_value=(True, "device-token")):
+                token = await mgr.get_access_token()
+                assert token == "device-token"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_all_methods_fail(self, tmp_path, oauth_config):
+        cache_file = tmp_path / ".kion_mcp_token_cache.json"
+        with patch.object(OAuthManager, '_cache_file_path', return_value=cache_file):
+            mgr = OAuthManager(oauth_config)
+            with patch.object(mgr, 'run_device_flow', new_callable=AsyncMock, return_value=(False, "flow failed")):
+                with pytest.raises(AuthenticationError, match="flow failed"):
+                    await mgr.get_access_token()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,74 @@
+"""Tests for KionConfig OAuth fields."""
+
+import os
+import pytest
+import yaml
+from unittest.mock import patch
+from kion_mcp.config.settings import KionConfig
+
+
+class TestOAuthConfigFields:
+    """Test oauth_client_id and oauth_scopes on KionConfig."""
+
+    def test_default_oauth_fields_are_none(self, base_config):
+        config = KionConfig()
+        assert config.oauth_client_id is None
+        assert config.oauth_scopes == "openid offline_access"
+
+    def test_is_oauth_mode_when_client_id_set(self, oauth_config):
+        assert oauth_config.is_oauth_mode() is True
+
+    def test_is_oauth_mode_when_client_id_not_set(self, base_config):
+        assert base_config.is_oauth_mode() is False
+
+    def test_needs_configuration_false_with_oauth(self, oauth_config):
+        assert oauth_config.needs_configuration() is False
+
+    def test_oauth_from_environment(self):
+        env = {
+            "KION_SERVER_URL": "https://kion.example.com",
+            "KION_OAUTH_CLIENT_ID": "env-client-id",
+            "KION_OAUTH_SCOPES": "openid",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = KionConfig()
+            config._load_from_environment()
+            assert config.oauth_client_id == "env-client-id"
+            assert config.oauth_scopes == "openid"
+
+    def test_oauth_from_environment_default_scopes(self):
+        env = {
+            "KION_SERVER_URL": "https://kion.example.com",
+            "KION_OAUTH_CLIENT_ID": "env-client-id",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = KionConfig()
+            config._load_from_environment()
+            assert config.oauth_client_id == "env-client-id"
+            assert config.oauth_scopes == "openid offline_access"
+
+    def test_oauth_from_yaml_file(self, tmp_path):
+        config_file = tmp_path / "kion_mcp_config.yaml"
+        config_file.write_text(yaml.dump({
+            "server_base_url": "https://kion.example.com",
+            "oauth_client_id": "yaml-client-id",
+            "oauth_scopes": "openid offline_access profile",
+        }))
+        config = KionConfig()
+        config._config_path = config_file
+        with open(config_file, "r") as f:
+            config_data = yaml.safe_load(f)
+        config.server_base_url = config._process_server_url(config_data.get("server_base_url"))
+        config.oauth_client_id = config_data.get("oauth_client_id")
+        config.oauth_scopes = config_data.get("oauth_scopes", "openid offline_access")
+        assert config.oauth_client_id == "yaml-client-id"
+        assert config.oauth_scopes == "openid offline_access profile"
+
+    def test_save_includes_oauth_fields(self, tmp_path, oauth_config):
+        config_file = tmp_path / "kion_mcp_config.yaml"
+        oauth_config._config_path = config_file
+        oauth_config.save()
+        with open(config_file, "r") as f:
+            saved = yaml.safe_load(f)
+        assert saved["oauth_client_id"] == "test-client-id"
+        assert saved["oauth_scopes"] == "openid offline_access"

--- a/uv.lock
+++ b/uv.lock
@@ -404,6 +404,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -524,14 +533,23 @@ dependencies = [
     { name = "starlette" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "authlib", specifier = ">=1.6.9" },
     { name = "fastmcp", specifier = ">=2.14.5,<3" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "starlette", specifier = ">=0.49.1" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "lupa"
@@ -688,6 +706,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -890,6 +917,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add OAuth Device Authorization Flow (RFC 8628) as a third authentication method alongside bearer tokens and auth scripts
- Implement automatic token refresh with device flow fallback when refresh token expires
- Persist tokens in a separate cache file (`~/.kion_mcp_token_cache.json`) with 0600 permissions
- Add OAuth option to the interactive config setup wizard
- Auth priority chain: bearer_token > cached OAuth > device flow > auth_script

## Details

### New: OAuthManager (`src/kion_mcp/config/oauth.py`)
- Device authorization flow: request device code, open browser, poll for token
- Token refresh: automatic refresh using cached refresh token
- Token cache: JSON file with server URL validation, expiry tracking
- Browser launch: macOS/Linux/Windows support with localhost port mapping

### Modified
- **KionConfig**: `oauth_client_id`, `oauth_scopes` fields + env var support (`KION_OAUTH_CLIENT_ID`, `KION_OAUTH_SCOPES`)
- **AuthManager**: Integrated OAuth into auth priority chain and token refresh
- **Config setup wizard**: OAuth as an auth method choice with inline device flow validation
- **Server startup**: Graceful handling of OAuth first-run (no cached token)

### Aligned with upstream
- Endpoint paths match portal `add-oauth-support` branch: `/device_authorization`, `/token` (root-level, not `/oauth/` prefixed)
- Tokens are native Kion JWTs (portal replaced opaque tokens)
- Localhost port mapping (8081→8080) matches kion-cli behavior

## Test plan

- [x] 46 unit tests passing (OAuthManager, config fields, auth priority chain)
- [x] End-to-end tested against local Kion instance with OAuth enabled
- [ ] Test with Claude Desktop MCP client integration
- [ ] Test DXT mode with `KION_OAUTH_CLIENT_ID` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)